### PR TITLE
Minor - enable python 3.8 runtime for non-default lambda layers (#29)

### DIFF
--- a/sdlf-pipLibrary/build.sh
+++ b/sdlf-pipLibrary/build.sh
@@ -22,7 +22,7 @@ do
         echo "Uploading Lambda Layer as sdlf-$team_name-$dir_name..."
         
         set +e
-        layer=$(aws lambda publish-layer-version --layer-name sdlf-$team_name-$dir_name --description "Contains the libraries specified in requirements.txt" --compatible-runtimes "python3.6" "python3.7" --zip-file fileb://./layer.zip)
+        layer=$(aws lambda publish-layer-version --layer-name sdlf-$team_name-$dir_name --description "Contains the libraries specified in requirements.txt" --compatible-runtimes "python3.6" "python3.7" "python3.8" --zip-file fileb://./layer.zip)
         status=$?
         set -e
 


### PR DESCRIPTION
* Add step function SAM packaging feature

* Update step function SAM packaging feature

* update sam packaging feature for sdlf-util cloudfront

* update with latest sam packaging

* Add SAM packaging functionality for step functions

* Minor - enable python 3.8 runtime for non-default lambda layers